### PR TITLE
ASoC: Intel: sof_sdw: use PRODUCT_FAMILY for Fatcat series

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -772,7 +772,7 @@ static const struct dmi_system_id sof_sdw_quirk_table[] = {
 		.callback = sof_sdw_quirk_cb,
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "Google"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "Fatcat"),
+			DMI_MATCH(DMI_PRODUCT_FAMILY, "Google_Fatcat"),
 		},
 		.driver_data = (void *)(SOC_SDW_PCH_DMIC |
 					SOF_BT_OFFLOAD_SSP(2) |


### PR DESCRIPTION
PRODUCT_NAME is machine-specific. Use PRODUCT_FAMILY to ensure the machine quirk is applied with consistent audio configurations across Fatcat series products.