### PR TITLE
ASoC: SOF: Intel: hda: add SDCA property check

### DIFF
--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -1138,6 +1138,12 @@ static bool is_endpoint_present(struct sdw_slave *sdw_device,
 {
 	int i;
 
+	/* If SDCA is not present, assume the endpoint is present */
+	if (!sdw_device->sdca_data.interface_revision) {
+		dev_warn(&sdw_device->dev, "SDCA properties not found in BIOS\n");
+		return true;
+	}
+
 	for (i = 0; i < sdw_device->sdca_data.num_functions; i++) {
 		if (dai_type == dai_info->dais[i].dai_type)
 			return true;


### PR DESCRIPTION
If SDCA property is not present in the DisCo table, do not skip codec dai endpoints. This ensures that dai links can still be
created from codec_info_list instead of being ignored.
By enabling the default SoundWire driver and best_effort tplg on PTL, functional topologies work on RT721 and multi-lane amplifier on link 3.

Singed-off-by: Mac Chiang <mac.chiang@intel.com>