### PR TITLE
ASoC: soc-acpi-intel-arl-match: add rt713_l0_rt1320_l2 support

### DIFF
--- a/sound/soc/intel/common/soc-acpi-intel-arl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-arl-match.c
@@ -46,6 +46,23 @@ static const struct snd_soc_acpi_endpoint spk_3_endpoint = {
 	.group_id = 1,
 };
 
+static const struct snd_soc_acpi_endpoint jack_dmic_endpoints[] = {
+        /* Jack Endpoint */
+        {
+                .num = 0,
+                .aggregated = 0,
+                .group_position = 0,
+                .group_id = 0,
+        },
+        /* DMIC Endpoint */
+        {
+                .num = 1,
+                .aggregated = 0,
+                .group_position = 0,
+                .group_id = 0,
+        },
+};
+
 static const struct snd_soc_acpi_endpoint jack_amp_g1_dmic_endpoints[] = {
 	/* Jack Endpoint */
 	{
@@ -283,6 +300,15 @@ static const struct snd_soc_acpi_adr_device rt712_0_agg_adr[] = {
 	}
 };
 
+static const struct snd_soc_acpi_adr_device rt713_vb_0_adr[] = {
+	{
+		.adr = 0x000030025d071301ull,
+		.num_endpoints = ARRAY_SIZE(jack_dmic_endpoints),
+		.endpoints = jack_dmic_endpoints,
+		.name_prefix = "rt713"
+	}
+};
+
 static const struct snd_soc_acpi_adr_device rt1316_3_single_adr[] = {
 	{
 		.adr = 0x000330025D131601ull,
@@ -301,6 +327,20 @@ static const struct snd_soc_acpi_adr_device rt1320_2_single_adr[] = {
 	}
 };
 
+static const struct snd_soc_acpi_adr_device rt1320_2_lr_adr[] = {
+	{
+		.adr = 0x000230025D132001ull,
+		.num_endpoints = 1,
+		.endpoints = &spk_l_endpoint,
+		.name_prefix = "rt1320-1"
+	},
+	{
+		.adr = 0x000231025D132001ull,
+		.num_endpoints = 1,
+		.endpoints = &spk_r_endpoint,
+		.name_prefix = "rt1320-1"
+	}
+};
 static const struct snd_soc_acpi_link_adr arl_n_mrd_es9356_link1[] = {
 	{
 		.mask = BIT(1),
@@ -482,6 +522,20 @@ static const struct snd_soc_acpi_link_adr arl_rt712_l0_rt1320_l3[] = {
 	{}
 };
 
+static const struct snd_soc_acpi_link_adr arl_rt713_vb_l0_rt1320_l2[] = {
+	{
+		.mask = BIT(0),
+		.num_adr = ARRAY_SIZE(rt713_vb_0_adr),
+		.adr_d = rt713_vb_0_adr,
+	},
+	{
+		.mask = BIT(2),
+		.num_adr = ARRAY_SIZE(rt1320_2_lr_adr),
+		.adr_d = rt1320_2_lr_adr,
+	},
+	{}
+};
+
 static const struct snd_soc_acpi_codecs arl_essx_83x6 = {
 	.num_codecs = 3,
 	.codecs = { "ESSX8316", "ESSX8326", "ESSX8336"},
@@ -558,6 +612,13 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_arl_sdw_machines[] = {
 		.links = arl_cs42l43_l0_cs35l56_l2,
 		.drv_name = "sof_sdw",
 		.sof_tplg_filename = "sof-arl-cs42l43-l0-cs35l56-l2.tplg",
+		.get_function_tplg_files = sof_sdw_get_tplg_files,
+	},
+	{
+		.link_mask = BIT(0) | BIT(2),
+		.links = arl_rt713_vb_l0_rt1320_l2,
+		.drv_name = "sof_sdw",
+		.sof_tplg_filename = "sof-arl-dummy.tplg",
 		.get_function_tplg_files = sof_sdw_get_tplg_files,
 	},
 	{


### PR DESCRIPTION
Add support for the RT713 JACK/DMIC codecs on link 0 and the RT1320 stereo amplifiers on link 2.